### PR TITLE
Add build script, CI workflows, and agent guidelines

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,14 @@
+name: build
+on:
+  push:
+  pull_request:
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v4
+    - run: bash build.sh
+    - uses: actions/upload-artifact@v4
+      with:
+        name: build
+        path: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: release
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: tag
+        required: true
+jobs:
+  release:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - run: bash build.sh
+    - run: tar -czf build.tar.gz build
+    - uses: softprops/action-gh-release@v1
+      with:
+        tag_name: ${{ github.event.inputs.tag }}
+        files: build.tar.gz
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+Agents working on this repository must explore every directory under /workspace and look for additional MD files, especially AGENTS.md. Read and remember the instructions in those files, and follow them when modifying any files within their scope.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,6 @@
+set -euo pipefail
+cd "$(dirname "$0")"
+mkdir -p build
+cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release
+make -j


### PR DESCRIPTION
## Summary
- add bash build script
- run build and upload artifact on CI
- publish build outputs in Releases via manual workflow
- specify agent guidelines in AGENTS.md
- run CI on macOS runners

## Testing
- `shellcheck -s bash build.sh`
- `bash build.sh` *(fails: interrupted after configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68afe5014b54832da098104979ff7ec7